### PR TITLE
Fixed readme images for dark and light github themes.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="80%" src="https://github.com/dahliaos/brand/blob/master/Logo%20SVGs/dahliaOS%20logo%20with%20text%20(drop%20shadow).svg"
+  <img width="40%" src="https://raw.githubusercontent.com/dahliaOS/brand/master/dahliaOS/svg/logotypewhitetext.svg#gh-dark-mode-only"
 </p>
 
 <p align="center">

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="40%" src="https://raw.githubusercontent.com/dahliaOS/brand/master/dahliaOS/svg/logotypewhitetext.svg#gh-dark-mode-only"
+  <img width="30%" src="https://raw.githubusercontent.com/dahliaOS/brand/master/dahliaOS/svg/logotypewhitetext.svg#gh-dark-mode-only"
 </p>
 
 <p align="center">

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,7 +1,12 @@
 <p align="center">
   <img width="30%" src="https://raw.githubusercontent.com/dahliaOS/brand/master/dahliaOS/svg/logotypewhitetext.svg#gh-dark-mode-only"
+  
 </p>
-
+  
+<p align="center">
+  <img width="30%" src="https://github.com/dahliaOS/brand/blob/master/dahliaOS/svg/logotypeblacktext.svg#gh-light-mode-only"
+  
+</p>
 <p align="center">
 <a href="https://dahliaos.io">Website</a> ●
 <a href="https://discord.gg/7qVbJHR">Discord</a> ●


### PR DESCRIPTION
And this cannot be done from 'brand' repository