### PR TITLE
Disable paranoid unsafe path

### DIFF
--- a/.config
+++ b/.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot -gec0376d0-dirty Configuration
+# Buildroot -g9eac786b Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -153,7 +153,7 @@ BR2_GLOBAL_PATCH_DIR=""
 #
 # Advanced
 #
-BR2_COMPILER_PARANOID_UNSAFE_PATH=y
+# BR2_COMPILER_PARANOID_UNSAFE_PATH is not set
 # BR2_FORCE_HOST_BUILD is not set
 # BR2_REPRODUCIBLE is not set
 # BR2_PER_PACKAGE_DIRECTORIES is not set


### PR DESCRIPTION
Pangolin doesn't like to compile with this, so we disable BR2_COMPILER_PARANOID_UNSAFE_PATH.